### PR TITLE
Fix Error "ValueError: Segment matched in simple parsing, but failed later. Report this"

### DIFF
--- a/menu_of_workflows/fishtown_analytics/lint_models.yml
+++ b/menu_of_workflows/fishtown_analytics/lint_models.yml
@@ -11,6 +11,6 @@ jobs:
         with:
             python-version: "3.8"
       - name: Install SQLFluff
-        run: "pip install sqlfluff==0.3.6"
+        run: "pip install sqlfluff==0.5.3"
       - name: Lint models
         run: "sqlfluff lint models"


### PR DESCRIPTION
When I register version 0.3.6 of sqlfluff to github actions, I get an error at runtime.
I tried version 0.5.3 and it was successful.